### PR TITLE
Update dependencies and add Dependabot configuration

### DIFF
--- a/src/workers/song_items_creator.rs
+++ b/src/workers/song_items_creator.rs
@@ -154,6 +154,7 @@ impl SongItemsCreatorWorker {
     }
 
     /// Step 2: fetch RSS for all channels and insert new videos.
+    /// Videos with `liveBroadcastContent = "upcoming"` (配信開始前) are skipped.
     async fn fetch_and_insert_videos(
         &self,
         db: &sea_orm::DatabaseConnection,
@@ -175,6 +176,8 @@ impl SongItemsCreatorWorker {
                 }
             };
 
+            // Collect only new video IDs (not yet in DB), preserving published date from RSS.
+            let mut new_entries = Vec::new();
             for entry in entries {
                 let existing = videos_entity::Entity::find()
                     .filter(videos_entity::Column::VideoId.eq(&entry.video_id))
@@ -182,7 +185,41 @@ impl SongItemsCreatorWorker {
                     .await
                     .map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
 
-                if existing.is_some() {
+                if existing.is_none() {
+                    new_entries.push(entry);
+                }
+            }
+
+            if new_entries.is_empty() {
+                continue;
+            }
+
+            // Fetch video details from YouTube API to check liveBroadcastContent.
+            let video_ids: Vec<&str> = new_entries.iter().map(|e| e.video_id.as_str()).collect();
+            let video_infos = match youtube_client.fetch_video_info(&video_ids).await {
+                Ok(infos) => infos,
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to fetch video info for channel {}: {e}",
+                        channel.channel_id
+                    );
+                    continue;
+                }
+            };
+
+            // Build a map from video_id to liveBroadcastContent.
+            let broadcast_map: std::collections::HashMap<String, String> = video_infos
+                .into_iter()
+                .map(|info| (info.video_id, info.live_broadcast_content))
+                .collect();
+
+            for entry in new_entries {
+                // Skip videos that have not yet started broadcasting.
+                if broadcast_map.get(&entry.video_id).map(String::as_str) == Some("upcoming") {
+                    tracing::debug!(
+                        "Skipping upcoming video {} (not yet started)",
+                        entry.video_id
+                    );
                     continue;
                 }
 

--- a/src/workers/youtube_client.rs
+++ b/src/workers/youtube_client.rs
@@ -17,6 +17,7 @@ pub struct VideoInfo {
     pub video_id: String,
     pub title: String,
     pub published_at: String,
+    pub live_broadcast_content: String,
     pub response_json: serde_json::Value,
 }
 
@@ -68,6 +69,7 @@ struct VideoItem {
 struct VideoSnippet {
     title: String,
     published_at: String,
+    live_broadcast_content: String,
 }
 
 #[derive(Deserialize)]
@@ -183,6 +185,7 @@ impl YouTubeClient {
                     video_id: item.id,
                     title: item.snippet.title,
                     published_at: item.snippet.published_at,
+                    live_broadcast_content: item.snippet.live_broadcast_content,
                     response_json: snippet_json,
                 }
             })
@@ -280,9 +283,10 @@ fn parse_rss_entries(xml: &str) -> Vec<RssEntry> {
 impl serde::Serialize for VideoSnippet {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         use serde::ser::SerializeMap as _;
-        let mut map = serializer.serialize_map(Some(2))?;
+        let mut map = serializer.serialize_map(Some(3))?;
         map.serialize_entry("title", &self.title)?;
         map.serialize_entry("publishedAt", &self.published_at)?;
+        map.serialize_entry("liveBroadcastContent", &self.live_broadcast_content)?;
         map.end()
     }
 }


### PR DESCRIPTION
feat: RSSから取得した動画のうち配信開始前(upcoming)をDB挿入対象外にする。  
YouTube Data APIのliveBroadcastContentを確認し、upcomingの動画はスキップする。