### PR TITLE
feat: お気に入りページの曲一覧にVtuber名を表示する

### DIFF
--- a/frontend/src/components/SongLists/SongItemList.tsx
+++ b/frontend/src/components/SongLists/SongItemList.tsx
@@ -10,6 +10,7 @@ type Props = {
   favoriteIds?: Set<number>;
   showFavorite?: boolean;
   showEdit?: boolean;
+  showChannel?: boolean;
 };
 
 export function SongItemList({
@@ -20,6 +21,7 @@ export function SongItemList({
   favoriteIds,
   showFavorite = false,
   showEdit = false,
+  showChannel = false,
 }: Props) {
   if (items.length === 0) {
     return <p className="text-body-secondary">曲が見つかりませんでした。</p>;
@@ -35,6 +37,7 @@ export function SongItemList({
               <th scope="col">時間</th>
               <th scope="col">曲名</th>
               <th scope="col">アーティスト</th>
+              {showChannel && <th scope="col">Vtuber</th>}
               <th scope="col">動画</th>
               {showEdit && <th scope="col" style={{ width: "5rem" }} />}
             </tr>
@@ -46,6 +49,7 @@ export function SongItemList({
                 item={item}
                 showFavorite={showFavorite}
                 showEdit={showEdit}
+                showChannel={showChannel}
                 favorited={favoriteIds?.has(item.id) ?? false}
               />
             ))}

--- a/frontend/src/components/SongLists/SongItemRow.tsx
+++ b/frontend/src/components/SongLists/SongItemRow.tsx
@@ -13,6 +13,7 @@ type Props = {
   favorited?: boolean;
   showFavorite?: boolean;
   showEdit?: boolean;
+  showChannel?: boolean;
 };
 
 function timeToSeconds(time: string): number {
@@ -64,6 +65,7 @@ export function SongItemRow({
   favorited = false,
   showFavorite = false,
   showEdit = false,
+  showChannel = false,
 }: Props) {
   const { diff, video } = item;
   const [modalOpen, setModalOpen] = useState(false);
@@ -100,6 +102,9 @@ export function SongItemRow({
         <td className="align-middle small">
           {diff.author ?? <span className="text-body-secondary">—</span>}
         </td>
+        {showChannel && (
+          <td className="align-middle small">{video.channel_custom_name}</td>
+        )}
         <td className="align-middle small">
           <a
             href={youtubeUrl(video.video_id)}

--- a/frontend/src/containers/Favorites/FavoriteList.tsx
+++ b/frontend/src/containers/Favorites/FavoriteList.tsx
@@ -26,6 +26,7 @@ export function FavoriteList() {
       onPageChange={() => undefined}
       favoriteIds={favoriteIds}
       showFavorite
+      showChannel
     />
   );
 }

--- a/frontend/src/resources/types.ts
+++ b/frontend/src/resources/types.ts
@@ -34,6 +34,7 @@ export type SongItemType = {
     video_id: string;
     title: string;
     channel_id: number;
+    channel_custom_name: string;
     kind: number;
     published_at: string;
   };

--- a/src/controllers/member/favorites.rs
+++ b/src/controllers/member/favorites.rs
@@ -31,6 +31,7 @@ struct VideoInfo {
     video_id: String,
     title: String,
     channel_id: i64,
+    channel_custom_name: String,
     kind: i32,
     published_at: sea_orm::prelude::DateTimeWithTimeZone,
 }
@@ -60,6 +61,7 @@ impl From<SongItemRow> for SongItemResponse {
                 video_id: r.v_video_id,
                 title: r.v_title,
                 channel_id: r.v_channel_id,
+                channel_custom_name: r.v_channel_custom_name,
                 kind: r.v_kind,
                 published_at: r.v_published_at,
             },

--- a/src/controllers/song_items.rs
+++ b/src/controllers/song_items.rs
@@ -28,6 +28,7 @@ struct VideoInfo {
     video_id: String,
     title: String,
     channel_id: i64,
+    channel_custom_name: String,
     kind: i32,
     published_at: sea_orm::prelude::DateTimeWithTimeZone,
 }
@@ -57,6 +58,7 @@ impl From<SongItemRow> for SongItemResponse {
                 video_id: r.v_video_id,
                 title: r.v_title,
                 channel_id: r.v_channel_id,
+                channel_custom_name: r.v_channel_custom_name,
                 kind: r.v_kind,
                 published_at: r.v_published_at,
             },

--- a/src/models/favorites.rs
+++ b/src/models/favorites.rs
@@ -40,12 +40,14 @@ impl Model {
                 v.channel_id    AS v_channel_id,
                 v.kind          AS v_kind,
                 v.published_at  AS v_published_at,
+                c.custom_name   AS v_channel_custom_name,
                 sd.title        AS diff_title,
                 sd.author       AS diff_author,
                 sd.time         AS diff_time
             FROM favorites f
             INNER JOIN song_items si ON f.song_item_id = si.id
             INNER JOIN videos     v  ON si.video_id    = v.id
+            INNER JOIN channels   c  ON v.channel_id   = c.id
             LEFT  JOIN song_diffs sd ON si.latest_diff_id = sd.id
             WHERE f.user_id = $1
               AND si.latest_diff_id IS NOT NULL

--- a/src/models/song_items.rs
+++ b/src/models/song_items.rs
@@ -55,6 +55,8 @@ pub struct SongItemRow {
     pub v_channel_id: i64,
     pub v_kind: i32,
     pub v_published_at: sea_orm::prelude::DateTimeWithTimeZone,
+    // channel fields
+    pub v_channel_custom_name: String,
     // diff fields
     pub diff_title: Option<String>,
     pub diff_author: Option<String>,
@@ -72,11 +74,13 @@ fn build_query(params: &SongItemsParams) -> (String, Vec<sea_orm::Value>) {
             v.channel_id AS v_channel_id,
             v.kind      AS v_kind,
             v.published_at AS v_published_at,
+            c.custom_name AS v_channel_custom_name,
             sd.title    AS diff_title,
             sd.author   AS diff_author,
             sd.time     AS diff_time
         FROM song_items si
-        INNER JOIN videos v ON si.video_id = v.id
+        INNER JOIN videos   v ON si.video_id  = v.id
+        INNER JOIN channels c ON v.channel_id = c.id
         LEFT  JOIN song_diffs sd ON si.latest_diff_id = sd.id
         WHERE si.latest_diff_id IS NOT NULL
           AND v.published = true
@@ -175,11 +179,13 @@ impl SongItemRow {
                 v.channel_id AS v_channel_id,
                 v.kind      AS v_kind,
                 v.published_at AS v_published_at,
+                c.custom_name AS v_channel_custom_name,
                 sd.title    AS diff_title,
                 sd.author   AS diff_author,
                 sd.time     AS diff_time
             FROM song_items si
-            INNER JOIN videos v ON si.video_id = v.id
+            INNER JOIN videos   v ON si.video_id  = v.id
+            INNER JOIN channels c ON v.channel_id = c.id
             LEFT  JOIN song_diffs sd ON si.latest_diff_id = sd.id
             WHERE si.id = $1
         ";
@@ -216,11 +222,13 @@ impl SongItemRow {
                 v.channel_id AS v_channel_id,
                 v.kind      AS v_kind,
                 v.published_at AS v_published_at,
+                c.custom_name AS v_channel_custom_name,
                 sd.title    AS diff_title,
                 sd.author   AS diff_author,
                 sd.time     AS diff_time
             FROM song_items si
-            INNER JOIN videos v ON si.video_id = v.id
+            INNER JOIN videos   v ON si.video_id  = v.id
+            INNER JOIN channels c ON v.channel_id = c.id
             LEFT  JOIN song_diffs sd ON si.latest_diff_id = sd.id
             WHERE si.video_id = $1
             ORDER BY sd.time ASC NULLS LAST


### PR DESCRIPTION
## Summary

- `SongItemRow`（Rust）に `channels` テーブルの JOIN を追加し、`v_channel_custom_name` を取得
- `song_items` / `favorites` コントローラの `VideoInfo` に `channel_custom_name` を追加
- フロントエンドの `SongItemList` と `SongItemRow` に `showChannel` prop を追加
- `FavoriteList` で `showChannel` を有効化し、Vtuber名カラムを表示

closes #54

## Test plan

- [x] お気に入りページ（`/favorites`）の曲一覧に「Vtuber」列が表示されること
- [x] 他のページ（トップ・チャンネル詳細）では Vtuber 列が表示されないこと
- [x] バックエンドのビルド・lint・format check がすべて通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)