### PR TITLE
feat: YouTube Shortを動画取得から除外する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,3 +88,9 @@ Rules:
 - 小文字統一
 - 短く端的に（3〜5単語程度）
 - Issue番号があれば含める
+
+## Starting a New Task
+
+Before writing any code, always:
+1. Create a GitHub issue: `gh issue create --title "..." --body "..."`
+2. Create a branch following the naming convention: `git checkout -b <type>/<issue-id>-<short-description>`

--- a/src/workers/song_items_creator.rs
+++ b/src/workers/song_items_creator.rs
@@ -210,27 +210,38 @@ impl SongItemsCreatorWorker {
                 }
             };
 
-            // Build a map from video_id to (liveBroadcastContent, actualStartTime).
-            let info_map: std::collections::HashMap<String, (String, Option<String>)> = video_infos
-                .into_iter()
-                .map(|info| {
-                    (
-                        info.video_id,
-                        (info.live_broadcast_content, info.actual_start_time),
-                    )
-                })
-                .collect();
+            // Build a map from video_id to (liveBroadcastContent, actualStartTime, durationSeconds).
+            let info_map: std::collections::HashMap<String, (String, Option<String>, Option<u64>)> =
+                video_infos
+                    .into_iter()
+                    .map(|info| {
+                        (
+                            info.video_id,
+                            (info.live_broadcast_content, info.actual_start_time, info.duration_seconds),
+                        )
+                    })
+                    .collect();
 
             for entry in new_entries {
-                let (broadcast_content, actual_start_time) = info_map
+                let (broadcast_content, actual_start_time, duration_seconds) = info_map
                     .get(&entry.video_id)
-                    .map_or(("", None), |(b, a)| (b.as_str(), a.as_deref()));
+                    .map_or(("", None, None), |(b, a, d)| (b.as_str(), a.as_deref(), *d));
 
                 // Skip videos that have not yet started broadcasting.
                 if broadcast_content == "upcoming" {
                     tracing::debug!(
                         "Skipping upcoming video {} (not yet started)",
                         entry.video_id
+                    );
+                    continue;
+                }
+
+                // Skip YouTube Shorts (duration <= 60 seconds).
+                if duration_seconds.is_some_and(|d| d <= 60) {
+                    tracing::debug!(
+                        "Skipping short video {} (duration {:?}s)",
+                        entry.video_id,
+                        duration_seconds
                     );
                     continue;
                 }

--- a/src/workers/song_items_creator.rs
+++ b/src/workers/song_items_creator.rs
@@ -217,7 +217,11 @@ impl SongItemsCreatorWorker {
                     .map(|info| {
                         (
                             info.video_id,
-                            (info.live_broadcast_content, info.actual_start_time, info.duration_seconds),
+                            (
+                                info.live_broadcast_content,
+                                info.actual_start_time,
+                                info.duration_seconds,
+                            ),
                         )
                     })
                     .collect();

--- a/src/workers/youtube_client.rs
+++ b/src/workers/youtube_client.rs
@@ -19,6 +19,7 @@ pub struct VideoInfo {
     pub published_at: String,
     pub actual_start_time: Option<String>,
     pub live_broadcast_content: String,
+    pub duration_seconds: Option<u64>,
     pub response_json: serde_json::Value,
 }
 
@@ -63,7 +64,13 @@ struct VideoListResponse {
 struct VideoItem {
     id: String,
     snippet: VideoSnippet,
+    content_details: Option<VideoContentDetails>,
     live_streaming_details: Option<LiveStreamingDetails>,
+}
+
+#[derive(Deserialize)]
+struct VideoContentDetails {
+    duration: String,
 }
 
 #[derive(Deserialize)]
@@ -173,7 +180,7 @@ impl YouTubeClient {
         let ids = video_ids.join(",");
         let url = format!(
             "https://www.googleapis.com/youtube/v3/videos\
-             ?part=snippet%2CliveStreamingDetails&id={ids}&key={}",
+             ?part=snippet%2CcontentDetails%2CliveStreamingDetails&id={ids}&key={}",
             self.api_key
         );
         let resp: VideoListResponse = self
@@ -198,6 +205,9 @@ impl YouTubeClient {
                         .live_streaming_details
                         .and_then(|d| d.actual_start_time),
                     live_broadcast_content: item.snippet.live_broadcast_content,
+                    duration_seconds: item
+                        .content_details
+                        .map(|d| parse_iso8601_duration(&d.duration)),
                     response_json: snippet_json,
                 }
             })
@@ -289,6 +299,18 @@ fn parse_rss_entries(xml: &str) -> Vec<RssEntry> {
             published: published_dates.get(i).map_or("", |s| *s).to_string(),
         })
         .collect()
+}
+
+/// Parses an ISO 8601 duration string (e.g. `PT1M30S`) into total seconds.
+/// Returns 0 if the string cannot be parsed.
+fn parse_iso8601_duration(duration: &str) -> u64 {
+    let re = Regex::new(r"PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?").expect("static regex is valid");
+    re.captures(duration).map_or(0, |caps| {
+        let hours: u64 = caps.get(1).and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
+        let minutes: u64 = caps.get(2).and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
+        let seconds: u64 = caps.get(3).and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
+        hours * 3600 + minutes * 60 + seconds
+    })
 }
 
 // Make VideoSnippet serializable for response_json

--- a/src/workers/youtube_client.rs
+++ b/src/workers/youtube_client.rs
@@ -306,9 +306,18 @@ fn parse_rss_entries(xml: &str) -> Vec<RssEntry> {
 fn parse_iso8601_duration(duration: &str) -> u64 {
     let re = Regex::new(r"PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?").expect("static regex is valid");
     re.captures(duration).map_or(0, |caps| {
-        let hours: u64 = caps.get(1).and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
-        let minutes: u64 = caps.get(2).and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
-        let seconds: u64 = caps.get(3).and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
+        let hours: u64 = caps
+            .get(1)
+            .and_then(|m| m.as_str().parse().ok())
+            .unwrap_or(0);
+        let minutes: u64 = caps
+            .get(2)
+            .and_then(|m| m.as_str().parse().ok())
+            .unwrap_or(0);
+        let seconds: u64 = caps
+            .get(3)
+            .and_then(|m| m.as_str().parse().ok())
+            .unwrap_or(0);
         hours * 3600 + minutes * 60 + seconds
     })
 }


### PR DESCRIPTION
## Summary
- `videos.list` の `part` に `contentDetails` を追加し `duration` を取得
- ISO 8601 duration をパースして 60 秒以下の動画を Short と判定してスキップ

## Test plan
- [ ] Short動画（60秒以下）がDBにインサートされないことを確認
- [ ] 通常動画（60秒超）は従来通りインサートされることを確認
- [ ] ライブアーカイブ（60秒超）は除外されないことを確認

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)