### PR TITLE
fix: pnpm v10のビルドスクリプトセキュリティ制限に対応

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,9 @@
     "styled-components": "^6.1.19",
     "swr": "^2.3.0"
   },
+  "pnpm": {
+    "onlyBuiltDependencies": ["@parcel/watcher", "sharp", "unrs-resolver"]
+  },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",
     "@testing-library/jest-dom": "^6.6.0",


### PR DESCRIPTION
## Summary

- pnpm v10 からビルドスクリプトがデフォルトでブロックされる仕様変更により、CI の Install dependencies ステップで `[ERR_PNPM_IGNORED_BUILDS]` が発生していた
- `frontend/package.json` に `pnpm.onlyBuiltDependencies` を追加し、ネイティブモジュールのビルドに必要な3パッケージを明示的に許可

**許可したパッケージ:**
- `@parcel/watcher` — Next.js のファイル監視（ネイティブアドオン）
- `sharp` — Next.js の画像最適化（libvips バインディング）
- `unrs-resolver` — Rust 製モジュールリゾルバ

## Test plan

- [ ] CI の Frontend Lint / Install dependencies が `ERR_PNPM_IGNORED_BUILDS` なしで通過すること
- [ ] ローカルで `pnpm install` を実行してエラーが出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)