### PR TITLE
fix: 配信日の表示・入力をJST基準に修正

### DIFF
--- a/frontend/src/containers/Admin/VideoForm.tsx
+++ b/frontend/src/containers/Admin/VideoForm.tsx
@@ -4,6 +4,18 @@ import { useAdminVideoActions } from "@/hooks/useAdminVideos";
 import { VideoKind, VideoStatus } from "@/resources/enums";
 import type { VideoType } from "@/resources/types";
 
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+function toJstDatetimeLocal(utcIso: string): string {
+  const jstMs = new Date(utcIso).getTime() + JST_OFFSET_MS;
+  return new Date(jstMs).toISOString().slice(0, 16);
+}
+
+function fromJstDatetimeLocalToUtc(jstLocal: string): string {
+  const utcMs = new Date(`${jstLocal}:00Z`).getTime() - JST_OFFSET_MS;
+  return new Date(utcMs).toISOString();
+}
+
 type FormValues = {
   title: string;
   published: boolean;
@@ -31,7 +43,7 @@ export function VideoForm({ video, onSuccess }: Props) {
       published: video.published,
       kind: video.kind,
       status: video.status,
-      published_at: video.published_at.slice(0, 16),
+      published_at: toJstDatetimeLocal(video.published_at),
     },
   });
 
@@ -42,7 +54,7 @@ export function VideoForm({ video, onSuccess }: Props) {
         published: values.published,
         kind: Number(values.kind),
         status: Number(values.status),
-        published_at: new Date(values.published_at).toISOString(),
+        published_at: fromJstDatetimeLocalToUtc(values.published_at),
       });
       addAlert("success", "動画を更新しました");
       onSuccess();


### PR DESCRIPTION
DBから取得したUTC値をJSTに変換してフォームに表示し、
入力されたJST値をUTCに変換してAPIへ送信する。