### PR TITLE
Add setlist fetching and bulk processing features to admin panel

### DIFF
--- a/frontend/src/containers/Admin/VideoList.tsx
+++ b/frontend/src/containers/Admin/VideoList.tsx
@@ -2,8 +2,9 @@ import { useState } from "react";
 import Link from "next/link";
 import { format } from "date-fns";
 import { ja } from "date-fns/locale";
-import { useAdminVideos } from "@/hooks/useAdminVideos";
+import { useAdminVideos, useAdminVideoActions } from "@/hooks/useAdminVideos";
 import { useAdminChannels } from "@/hooks/useAdminChannels";
+import { useAlerts } from "@/context/AlertsProvider";
 import { Loading } from "@/components/Common/Loading";
 import { Modal } from "@/components/Common/Modal";
 import { Pagination } from "@/components/SongLists/Pagination";
@@ -13,6 +14,24 @@ import { BulkCreateVideoForm } from "./BulkCreateVideoForm";
 import type { VideoType } from "@/resources/types";
 
 const PER_PAGE = 30;
+
+const STATUS_SONG_ITEMS_CREATED = 20;
+
+const STATUS_LABELS: Record<number, { label: string; cls: string }> = {
+  0: { label: "未処理", cls: "bg-secondary" },
+  10: { label: "取得済", cls: "bg-primary" },
+  11: { label: "コメント不可", cls: "bg-warning text-dark" },
+  20: { label: "セトリ作成済", cls: "bg-info text-dark" },
+  25: { label: "履歴補完済", cls: "bg-info text-dark" },
+  30: { label: "Spotify検索済", cls: "bg-info text-dark" },
+  35: { label: "Spotify完了", cls: "bg-info text-dark" },
+  40: { label: "完了", cls: "bg-success" },
+};
+
+function StatusBadge({ status }: { status: number }) {
+  const s = STATUS_LABELS[status] ?? { label: `status:${status}`, cls: "bg-secondary" };
+  return <span className={`badge ${s.cls}`}>{s.label}</span>;
+}
 
 type Props = {
   initialChannelId?: number;
@@ -25,9 +44,66 @@ export function VideoList({ initialChannelId }: Props) {
   const [editTarget, setEditTarget] = useState<VideoType | null>(null);
   const [showCreate, setShowCreate] = useState(false);
   const [showBulkCreate, setShowBulkCreate] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [processingIds, setProcessingIds] = useState<Set<number>>(new Set());
 
+  const { addAlert } = useAlerts();
   const { data: channels } = useAdminChannels();
   const { data: videos, isLoading } = useAdminVideos(channelId, onlySongLives, page);
+  const { fetchSetlist, bulkFetchSetlist } = useAdminVideoActions();
+
+  const allSelected =
+    !!videos && videos.length > 0 && videos.every((v) => selectedIds.has(v.id));
+  const someSelected = selectedIds.size > 0;
+
+  function toggleSelect(id: number) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function toggleSelectAll() {
+    if (allSelected) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(videos?.map((v) => v.id) ?? []));
+    }
+  }
+
+  async function handleFetchSetlist(videoId: number, force: boolean) {
+    setProcessingIds((prev) => new Set([...prev, videoId]));
+    try {
+      await fetchSetlist(videoId, force);
+      addAlert("success", force ? "強制再取得ジョブをキューしました" : "セトリ取得ジョブをキューしました");
+    } catch (e) {
+      addAlert("danger", e instanceof Error ? e.message : "エラーが発生しました");
+    } finally {
+      setProcessingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(videoId);
+        return next;
+      });
+    }
+  }
+
+  async function handleBulkFetchSetlist(force: boolean) {
+    if (selectedIds.size === 0) return;
+    try {
+      await bulkFetchSetlist(Array.from(selectedIds), force);
+      addAlert(
+        "success",
+        force
+          ? `${selectedIds.size}件の強制再取得ジョブをキューしました`
+          : `${selectedIds.size}件のセトリ取得ジョブをキューしました`
+      );
+      setSelectedIds(new Set());
+    } catch (e) {
+      addAlert("danger", e instanceof Error ? e.message : "エラーが発生しました");
+    }
+  }
 
   return (
     <div>
@@ -80,6 +156,33 @@ export function VideoList({ initialChannelId }: Props) {
         </div>
       </div>
 
+      {someSelected && (
+        <div className="d-flex align-items-center gap-2 mb-3 p-2 bg-body-secondary rounded">
+          <span className="small text-body-secondary">{selectedIds.size}件選択中</span>
+          <button
+            type="button"
+            className="btn btn-sm btn-outline-primary"
+            onClick={() => handleBulkFetchSetlist(false)}
+          >
+            セトリ取得
+          </button>
+          <button
+            type="button"
+            className="btn btn-sm btn-outline-danger"
+            onClick={() => handleBulkFetchSetlist(true)}
+          >
+            強制再取得
+          </button>
+          <button
+            type="button"
+            className="btn btn-sm btn-link text-body-secondary"
+            onClick={() => setSelectedIds(new Set())}
+          >
+            選択解除
+          </button>
+        </div>
+      )}
+
       {isLoading ? (
         <Loading />
       ) : !videos || videos.length === 0 ? (
@@ -90,22 +193,39 @@ export function VideoList({ initialChannelId }: Props) {
             <table className="table table-sm small">
               <thead className="table-light">
                 <tr>
+                  <th style={{ width: "2rem" }}>
+                    <input
+                      type="checkbox"
+                      className="form-check-input"
+                      checked={allSelected}
+                      onChange={toggleSelectAll}
+                    />
+                  </th>
                   <th>ID</th>
                   <th>タイトル</th>
                   <th>配信日</th>
+                  <th>ステータス</th>
                   <th>公開</th>
                   <th>操作</th>
                 </tr>
               </thead>
               <tbody>
                 {videos.map((video) => {
-                  const publishedAt = format(
-                    new Date(video.published_at),
-                    "yyyy/MM/dd",
-                    { locale: ja }
-                  );
+                  const publishedAt = format(new Date(video.published_at), "yyyy/MM/dd", {
+                    locale: ja,
+                  });
+                  const isProcessing = processingIds.has(video.id);
+                  const isProcessed = video.status >= STATUS_SONG_ITEMS_CREATED;
                   return (
                     <tr key={video.id}>
+                      <td>
+                        <input
+                          type="checkbox"
+                          className="form-check-input"
+                          checked={selectedIds.has(video.id)}
+                          onChange={() => toggleSelect(video.id)}
+                        />
+                      </td>
                       <td>{video.id}</td>
                       <td>
                         <a
@@ -116,13 +236,16 @@ export function VideoList({ initialChannelId }: Props) {
                         >
                           <span
                             className="d-inline-block text-truncate"
-                            style={{ maxWidth: "20rem" }}
+                            style={{ maxWidth: "18rem" }}
                           >
                             {video.title}
                           </span>
                         </a>
                       </td>
                       <td className="text-body-secondary">{publishedAt}</td>
+                      <td>
+                        <StatusBadge status={video.status} />
+                      </td>
                       <td>
                         {video.published ? (
                           <span className="badge bg-success">公開</span>
@@ -131,7 +254,7 @@ export function VideoList({ initialChannelId }: Props) {
                         )}
                       </td>
                       <td>
-                        <div className="d-flex gap-1">
+                        <div className="d-flex gap-1 flex-wrap">
                           <button
                             type="button"
                             className="btn btn-xs btn-sm btn-outline-secondary"
@@ -148,6 +271,25 @@ export function VideoList({ initialChannelId }: Props) {
                           >
                             セトリ
                           </Link>
+                          {!isProcessed ? (
+                            <button
+                              type="button"
+                              className="btn btn-xs btn-sm btn-outline-primary"
+                              disabled={isProcessing}
+                              onClick={() => handleFetchSetlist(video.id, false)}
+                            >
+                              {isProcessing ? "…" : "セトリ取得"}
+                            </button>
+                          ) : (
+                            <button
+                              type="button"
+                              className="btn btn-xs btn-sm btn-outline-danger"
+                              disabled={isProcessing}
+                              onClick={() => handleFetchSetlist(video.id, true)}
+                            >
+                              {isProcessing ? "…" : "再取得"}
+                            </button>
+                          )}
                         </div>
                       </td>
                     </tr>
@@ -165,21 +307,13 @@ export function VideoList({ initialChannelId }: Props) {
         </>
       )}
 
-      <Modal
-        show={editTarget !== null}
-        onClose={() => setEditTarget(null)}
-        title="動画編集"
-      >
+      <Modal show={editTarget !== null} onClose={() => setEditTarget(null)} title="動画編集">
         {editTarget && (
           <VideoForm video={editTarget} onSuccess={() => setEditTarget(null)} />
         )}
       </Modal>
 
-      <Modal
-        show={showCreate}
-        onClose={() => setShowCreate(false)}
-        title="動画を追加"
-      >
+      <Modal show={showCreate} onClose={() => setShowCreate(false)} title="動画を追加">
         <CreateVideoForm onSuccess={() => setShowCreate(false)} />
       </Modal>
 

--- a/frontend/src/hooks/useAdminVideos.ts
+++ b/frontend/src/hooks/useAdminVideos.ts
@@ -78,5 +78,21 @@ export function useAdminVideoActions() {
     return result;
   }
 
-  return { create, update, bulkCreate };
+  async function fetchSetlist(videoId: number, force = false): Promise<void> {
+    await apiFetch<{ message: string }>(`${KEY}/${videoId}/fetch_setlist`, {
+      method: "POST",
+      auth: true,
+      body: JSON.stringify({ force }),
+    });
+  }
+
+  async function bulkFetchSetlist(videoIds: number[], force = false): Promise<void> {
+    await apiFetch<{ message: string }>(`${KEY}/bulk_fetch_setlist`, {
+      method: "POST",
+      auth: true,
+      body: JSON.stringify({ video_ids: videoIds, force }),
+    });
+  }
+
+  return { create, update, bulkCreate, fetchSetlist, bulkFetchSetlist };
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,7 +16,10 @@ use std::path::Path;
 #[allow(unused_imports)]
 use crate::{
     controllers, initializers, models::_entities::users, tasks,
-    workers::song_items_creator::SongItemsCreatorWorker,
+    workers::{
+        setlist_fetch_worker::SetlistFetchWorker,
+        song_items_creator::SongItemsCreatorWorker,
+    },
 };
 
 pub struct App;
@@ -66,6 +69,7 @@ impl Hooks for App {
     }
     async fn connect_workers(ctx: &AppContext, queue: &Queue) -> Result<()> {
         queue.register(SongItemsCreatorWorker::build(ctx)).await?;
+        queue.register(SetlistFetchWorker::build(ctx)).await?;
         Ok(())
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,10 +15,11 @@ use std::path::Path;
 
 #[allow(unused_imports)]
 use crate::{
-    controllers, initializers, models::_entities::users, tasks,
+    controllers, initializers,
+    models::_entities::users,
+    tasks,
     workers::{
-        setlist_fetch_worker::SetlistFetchWorker,
-        song_items_creator::SongItemsCreatorWorker,
+        setlist_fetch_worker::SetlistFetchWorker, song_items_creator::SongItemsCreatorWorker,
     },
 };
 

--- a/src/controllers/admin/videos.rs
+++ b/src/controllers/admin/videos.rs
@@ -378,9 +378,7 @@ async fn bulk_fetch_setlist(
     require_admin(&auth, &ctx).await?;
 
     if body.video_ids.is_empty() {
-        return Err(loco_rs::Error::BadRequest(
-            "video_ids が空です".to_string(),
-        ));
+        return Err(loco_rs::Error::BadRequest("video_ids が空です".to_string()));
     }
 
     SetlistFetchWorker::perform_later(

--- a/src/controllers/admin/videos.rs
+++ b/src/controllers/admin/videos.rs
@@ -5,6 +5,7 @@ use crate::{
         videos::{self, ActiveModel, CreateVideoParams, UpdateVideoParams, VideosAdminParams},
     },
     workers::{
+        setlist_fetch_worker::{SetlistFetchWorker, SetlistFetchWorkerArgs},
         song_items_creator::{SongItemsCreatorWorker, SongItemsCreatorWorkerArgs},
         youtube_client::YouTubeClient,
     },
@@ -66,6 +67,17 @@ struct UpdateBody {
 #[derive(Debug, Deserialize)]
 struct BulkCreateBody {
     tsv: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct FetchSetlistBody {
+    force: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BulkFetchSetlistBody {
+    video_ids: Vec<i32>,
+    force: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]
@@ -331,6 +343,58 @@ async fn bulk_create(
     })
 }
 
+#[debug_handler]
+async fn fetch_setlist(
+    auth: auth::JWT,
+    State(ctx): State<AppContext>,
+    Path(id): Path<i32>,
+    Json(body): Json<FetchSetlistBody>,
+) -> Result<Response> {
+    require_admin(&auth, &ctx).await?;
+
+    videos_entity::Entity::find_by_id(id)
+        .one(&ctx.db)
+        .await?
+        .ok_or(loco_rs::Error::NotFound)?;
+
+    SetlistFetchWorker::perform_later(
+        &ctx,
+        SetlistFetchWorkerArgs {
+            video_ids: vec![id],
+            force: body.force.unwrap_or(false),
+        },
+    )
+    .await?;
+
+    format::json(serde_json::json!({ "message": "セトリ取得ジョブをキューしました" }))
+}
+
+#[debug_handler]
+async fn bulk_fetch_setlist(
+    auth: auth::JWT,
+    State(ctx): State<AppContext>,
+    Json(body): Json<BulkFetchSetlistBody>,
+) -> Result<Response> {
+    require_admin(&auth, &ctx).await?;
+
+    if body.video_ids.is_empty() {
+        return Err(loco_rs::Error::BadRequest(
+            "video_ids が空です".to_string(),
+        ));
+    }
+
+    SetlistFetchWorker::perform_later(
+        &ctx,
+        SetlistFetchWorkerArgs {
+            video_ids: body.video_ids,
+            force: body.force.unwrap_or(false),
+        },
+    )
+    .await?;
+
+    format::json(serde_json::json!({ "message": "セトリ取得ジョブをキューしました" }))
+}
+
 fn extract_video_id(input: &str) -> String {
     // https://www.youtube.com/watch?v=VIDEO_ID
     if let Some(pos) = input.find("v=") {
@@ -359,5 +423,7 @@ pub fn routes() -> Routes {
         .add("/", get(list))
         .add("/", post(create))
         .add("/bulk", post(bulk_create))
+        .add("/bulk_fetch_setlist", post(bulk_fetch_setlist))
         .add("/{id}", patch(update))
+        .add("/{id}/fetch_setlist", post(fetch_setlist))
 }

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -1,4 +1,5 @@
 pub mod openai_client;
+pub mod setlist_fetch_worker;
 pub mod slack_client;
 pub mod song_items_creator;
 pub mod spotify_client;

--- a/src/workers/setlist_fetch_worker.rs
+++ b/src/workers/setlist_fetch_worker.rs
@@ -1,0 +1,158 @@
+use loco_rs::prelude::*;
+use sea_orm::{ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, QueryFilter};
+use serde::{Deserialize, Serialize};
+
+use super::{
+    openai_client::OpenAIClient,
+    song_items_creator::{
+        backfill_history_for_video, backfill_spotify_for_video, process_song_items_for_video,
+    },
+    spotify_client::SpotifyClient,
+    youtube_client::YouTubeClient,
+};
+use crate::models::{
+    _entities::{song_diffs as song_diffs_entity, song_items as song_items_entity, videos as videos_entity},
+    videos::{self as videos_model, STATUS_FETCHED, STATUS_SONG_ITEMS_CREATED},
+};
+
+pub struct SetlistFetchWorker {
+    pub ctx: AppContext,
+}
+
+#[derive(Deserialize, Debug, Serialize)]
+pub struct SetlistFetchWorkerArgs {
+    pub video_ids: Vec<i32>,
+    pub force: bool,
+}
+
+#[async_trait]
+impl BackgroundWorker<SetlistFetchWorkerArgs> for SetlistFetchWorker {
+    fn build(ctx: &AppContext) -> Self {
+        Self { ctx: ctx.clone() }
+    }
+
+    async fn perform(&self, args: SetlistFetchWorkerArgs) -> Result<()> {
+        let db = &self.ctx.db;
+
+        let google_api_key =
+            std::env::var("GOOGLE_API_KEY").map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
+        let openai_api_key =
+            std::env::var("OPENAI_API_KEY").map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
+        let spotify_client_id =
+            std::env::var("SPOTIFY_CLIENT_ID").map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
+        let spotify_client_secret = std::env::var("SPOTIFY_CLIENT_SECRET")
+            .map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
+
+        let youtube_client = YouTubeClient::new(google_api_key);
+        let openai_client = OpenAIClient::new(openai_api_key);
+        let spotify_client = SpotifyClient::new(spotify_client_id, spotify_client_secret);
+
+        let mut total_created = 0usize;
+
+        for video_id in &args.video_ids {
+            let Some(video) = videos_entity::Entity::find_by_id(*video_id)
+                .one(db)
+                .await
+                .map_err(|e| loco_rs::Error::Any(Box::new(e)))?
+            else {
+                tracing::warn!("SetlistFetchWorker: video {video_id} not found, skipping");
+                continue;
+            };
+
+            if args.force {
+                reset_video_setlist(db, &video).await?;
+            } else if video.status >= STATUS_SONG_ITEMS_CREATED {
+                tracing::info!(
+                    "SetlistFetchWorker: video {video_id} already processed (status={}), skipping",
+                    video.status
+                );
+                continue;
+            }
+
+            // Re-fetch after potential status reset
+            let Some(video) = videos_entity::Entity::find_by_id(*video_id)
+                .one(db)
+                .await
+                .map_err(|e| loco_rs::Error::Any(Box::new(e)))?
+            else {
+                continue;
+            };
+
+            let created =
+                process_song_items_for_video(db, &video, &youtube_client, &openai_client).await?;
+            total_created += created;
+
+            // Run backfill only if song items were created
+            let Some(video) = videos_entity::Entity::find_by_id(*video_id)
+                .one(db)
+                .await
+                .map_err(|e| loco_rs::Error::Any(Box::new(e)))?
+            else {
+                continue;
+            };
+
+            if video.status >= STATUS_SONG_ITEMS_CREATED {
+                backfill_history_for_video(db, &video).await?;
+
+                let Some(video) = videos_entity::Entity::find_by_id(*video_id)
+                    .one(db)
+                    .await
+                    .map_err(|e| loco_rs::Error::Any(Box::new(e)))?
+                else {
+                    continue;
+                };
+
+                backfill_spotify_for_video(db, &video, &spotify_client).await?;
+            }
+        }
+
+        tracing::info!("SetlistFetchWorker完了: {}件の曲を作成", total_created);
+        Ok(())
+    }
+}
+
+/// Deletes all song items and diffs for `video`, then resets its status to `STATUS_FETCHED`.
+async fn reset_video_setlist(
+    db: &sea_orm::DatabaseConnection,
+    video: &videos_entity::Model,
+) -> Result<()> {
+    let video_id = i64::from(video.id);
+
+    let items = song_items_entity::Entity::find()
+        .filter(song_items_entity::Column::VideoId.eq(video_id))
+        .all(db)
+        .await
+        .map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
+
+    if !items.is_empty() {
+        let item_ids: Vec<i64> = items.iter().map(|i| i64::from(i.id)).collect();
+
+        // Null latest_diff_id to avoid FK constraint violation when deleting song_diffs
+        for item in items {
+            let mut active: song_items_entity::ActiveModel = item.into();
+            active.latest_diff_id = ActiveValue::set(None);
+            active
+                .update(db)
+                .await
+                .map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
+        }
+
+        song_diffs_entity::Entity::delete_many()
+            .filter(song_diffs_entity::Column::SongItemId.is_in(item_ids))
+            .exec(db)
+            .await
+            .map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
+
+        song_items_entity::Entity::delete_many()
+            .filter(song_items_entity::Column::VideoId.eq(video_id))
+            .exec(db)
+            .await
+            .map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
+    }
+
+    videos_model::Model::update_status(db, video.id, STATUS_FETCHED)
+        .await
+        .map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
+
+    Ok(())
+}

--- a/src/workers/setlist_fetch_worker.rs
+++ b/src/workers/setlist_fetch_worker.rs
@@ -11,7 +11,9 @@ use super::{
     youtube_client::YouTubeClient,
 };
 use crate::models::{
-    _entities::{song_diffs as song_diffs_entity, song_items as song_items_entity, videos as videos_entity},
+    _entities::{
+        song_diffs as song_diffs_entity, song_items as song_items_entity, videos as videos_entity,
+    },
     videos::{self as videos_model, STATUS_FETCHED, STATUS_SONG_ITEMS_CREATED},
 };
 
@@ -40,8 +42,8 @@ impl BackgroundWorker<SetlistFetchWorkerArgs> for SetlistFetchWorker {
             std::env::var("OPENAI_API_KEY").map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
         let spotify_client_id =
             std::env::var("SPOTIFY_CLIENT_ID").map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
-        let spotify_client_secret = std::env::var("SPOTIFY_CLIENT_SECRET")
-            .map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
+        let spotify_client_secret =
+            std::env::var("SPOTIFY_CLIENT_SECRET").map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
 
         let youtube_client = YouTubeClient::new(google_api_key);
         let openai_client = OpenAIClient::new(openai_api_key);

--- a/src/workers/song_items_creator.rs
+++ b/src/workers/song_items_creator.rs
@@ -367,10 +367,7 @@ pub async fn process_song_items_for_video(
                     .await
                     .map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
             } else {
-                tracing::warn!(
-                    "Failed to fetch comments for video {}: {e}",
-                    video.video_id
-                );
+                tracing::warn!("Failed to fetch comments for video {}: {e}", video.video_id);
             }
             return Ok(0);
         }

--- a/src/workers/song_items_creator.rs
+++ b/src/workers/song_items_creator.rs
@@ -276,7 +276,6 @@ impl SongItemsCreatorWorker {
     }
 
     /// Step 3: For each incomplete song-live video, fetch comments and create song items.
-    #[allow(clippy::too_many_lines)]
     async fn process_song_items(
         &self,
         db: &sea_orm::DatabaseConnection,
@@ -294,115 +293,11 @@ impl SongItemsCreatorWorker {
             if !is_song_live(&video.title) {
                 continue;
             }
-
-            let comments = match youtube_client.fetch_comments(&video.video_id).await {
-                Ok(c) => c,
-                Err(e) => {
-                    if e.status() == Some(reqwest::StatusCode::FORBIDDEN) {
-                        tracing::warn!(
-                            "Comments disabled for video {}, marking as skipped",
-                            video.video_id
-                        );
-                        videos_model::Model::update_status(db, video.id, STATUS_COMMENTS_DISABLED)
-                            .await
-                            .map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
-                    } else {
-                        tracing::warn!(
-                            "Failed to fetch comments for video {}: {e}",
-                            video.video_id
-                        );
-                    }
-                    continue;
-                }
-            };
-
-            // Upsert all comments
-            let mut saved_comments = Vec::new();
-            for comment_info in comments {
-                let saved = comments_model::ActiveModel::upsert(
-                    db,
-                    UpsertCommentParams {
-                        comment_id: comment_info.comment_id,
-                        video_id: i64::from(video.id),
-                        author: comment_info.author,
-                        content: comment_info.content,
-                        response_json: comment_info.response_json,
-                    },
-                )
-                .await
-                .map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
-                saved_comments.push(saved);
-            }
-
-            // Process setlist comments with OpenAI
-            let mut video_created = 0usize;
-            for comment in &saved_comments {
-                if !comment.is_setlist() {
-                    continue;
-                }
-
-                let entries = match openai_client.extract_setlist(&comment.content).await {
-                    Ok(e) => e,
-                    Err(e) => {
-                        tracing::warn!("OpenAI failed for comment {}: {e}", comment.id);
-                        continue;
-                    }
-                };
-
-                for entry in entries {
-                    // Create song_item
-                    let item = song_items::ActiveModel {
-                        video_id: ActiveValue::set(i64::from(video.id)),
-                        latest_diff_id: ActiveValue::set(None),
-                        ..Default::default()
-                    }
-                    .insert(db)
-                    .await
-                    .map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
-
-                    // Create song_diff (auto, approved) and update latest_diff_id
-                    let time = if entry.time.is_empty() {
-                        None
-                    } else {
-                        Some(entry.time)
-                    };
-                    let title = if entry.title.is_empty() {
-                        None
-                    } else {
-                        Some(entry.title)
-                    };
-                    let author = if entry.author.is_empty() {
-                        None
-                    } else {
-                        Some(entry.author)
-                    };
-
-                    song_diffs_model::ActiveModel::create_auto(
-                        db,
-                        i64::from(item.id),
-                        Some(i64::from(comment.id)),
-                        time,
-                        title,
-                        author,
-                    )
-                    .await
-                    .map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
-
-                    video_created += 1;
-                }
-
-                // Mark comment completed
-                comments_model::Model::mark_completed(db, comment.id)
-                    .await
-                    .map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
-            }
-
-            if video_created > 0 {
-                videos_model::Model::update_status(db, video.id, STATUS_SONG_ITEMS_CREATED)
-                    .await
-                    .map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
+            let count =
+                process_song_items_for_video(db, &video, youtube_client, openai_client).await?;
+            if count > 0 {
                 processed += 1;
-                created += video_created;
+                created += count;
             }
         }
 
@@ -418,23 +313,7 @@ impl SongItemsCreatorWorker {
             .map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
 
         for video in videos {
-            let empty_diffs = find_empty_author_diffs(db, i64::from(video.id)).await?;
-
-            for diff_row in empty_diffs {
-                let Some(title) = &diff_row.title else {
-                    continue;
-                };
-                if title.is_empty() {
-                    continue;
-                }
-                if let Some(author) = find_historical_author(db, title).await? {
-                    update_diff_author(db, diff_row.id, &author).await?;
-                }
-            }
-
-            videos_model::Model::update_status(db, video.id, STATUS_FETCHED_HISTORY)
-                .await
-                .map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
+            backfill_history_for_video(db, &video).await?;
         }
 
         Ok(())
@@ -453,37 +332,204 @@ impl SongItemsCreatorWorker {
             .map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
 
         for video in videos {
-            let empty_diffs = find_empty_author_diffs(db, i64::from(video.id)).await?;
-
-            for diff_row in empty_diffs {
-                let Some(title) = &diff_row.title else {
-                    continue;
-                };
-                if title.is_empty() {
-                    continue;
-                }
-
-                match spotify_client.search_artist(title).await {
-                    Ok(Some(author)) => {
-                        update_diff_author(db, diff_row.id, &author).await?;
-                        update_diff_status(db, diff_row.id, STATUS_SPOTIFY_COMPLETED).await?;
-                    }
-                    Ok(None) => {
-                        update_diff_status(db, diff_row.id, STATUS_SPOTIFY_FETCHED).await?;
-                    }
-                    Err(e) => {
-                        tracing::warn!("Spotify search failed for '{}': {e}", title);
-                    }
-                }
-            }
-
-            videos_model::Model::update_status(db, video.id, STATUS_COMPLETED)
-                .await
-                .map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
+            backfill_spotify_for_video(db, &video, spotify_client).await?;
         }
 
         Ok(())
     }
+}
+
+/// Fetches comments for `video` and creates song items from setlist comments.
+///
+/// Returns the number of song items created.
+/// Sets status to `STATUS_SONG_ITEMS_CREATED` if any items were created,
+/// or `STATUS_COMMENTS_DISABLED` if the video has comments disabled.
+/// The caller is responsible for keyword filtering (歌枠 etc.) if desired.
+///
+/// # Errors
+/// Returns an error if the `YouTube` API, `OpenAI` API, or database operations fail.
+#[allow(clippy::too_many_lines)]
+pub async fn process_song_items_for_video(
+    db: &sea_orm::DatabaseConnection,
+    video: &videos_entity::Model,
+    youtube_client: &YouTubeClient,
+    openai_client: &OpenAIClient,
+) -> Result<usize> {
+    let comments = match youtube_client.fetch_comments(&video.video_id).await {
+        Ok(c) => c,
+        Err(e) => {
+            if e.status() == Some(reqwest::StatusCode::FORBIDDEN) {
+                tracing::warn!(
+                    "Comments disabled for video {}, marking as skipped",
+                    video.video_id
+                );
+                videos_model::Model::update_status(db, video.id, STATUS_COMMENTS_DISABLED)
+                    .await
+                    .map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
+            } else {
+                tracing::warn!(
+                    "Failed to fetch comments for video {}: {e}",
+                    video.video_id
+                );
+            }
+            return Ok(0);
+        }
+    };
+
+    let mut saved_comments = Vec::new();
+    for comment_info in comments {
+        let saved = comments_model::ActiveModel::upsert(
+            db,
+            UpsertCommentParams {
+                comment_id: comment_info.comment_id,
+                video_id: i64::from(video.id),
+                author: comment_info.author,
+                content: comment_info.content,
+                response_json: comment_info.response_json,
+            },
+        )
+        .await
+        .map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
+        saved_comments.push(saved);
+    }
+
+    let mut created = 0usize;
+    for comment in &saved_comments {
+        if !comment.is_setlist() {
+            continue;
+        }
+
+        let entries = match openai_client.extract_setlist(&comment.content).await {
+            Ok(e) => e,
+            Err(e) => {
+                tracing::warn!("OpenAI failed for comment {}: {e}", comment.id);
+                continue;
+            }
+        };
+
+        for entry in entries {
+            let item = song_items::ActiveModel {
+                video_id: ActiveValue::set(i64::from(video.id)),
+                latest_diff_id: ActiveValue::set(None),
+                ..Default::default()
+            }
+            .insert(db)
+            .await
+            .map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
+
+            let time = if entry.time.is_empty() {
+                None
+            } else {
+                Some(entry.time)
+            };
+            let title = if entry.title.is_empty() {
+                None
+            } else {
+                Some(entry.title)
+            };
+            let author = if entry.author.is_empty() {
+                None
+            } else {
+                Some(entry.author)
+            };
+
+            song_diffs_model::ActiveModel::create_auto(
+                db,
+                i64::from(item.id),
+                Some(i64::from(comment.id)),
+                time,
+                title,
+                author,
+            )
+            .await
+            .map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
+
+            created += 1;
+        }
+
+        comments_model::Model::mark_completed(db, comment.id)
+            .await
+            .map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
+    }
+
+    if created > 0 {
+        videos_model::Model::update_status(db, video.id, STATUS_SONG_ITEMS_CREATED)
+            .await
+            .map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
+    }
+
+    Ok(created)
+}
+
+/// Fills empty `author` fields for `video` from historical approved diffs with the same title.
+/// Sets status to `STATUS_FETCHED_HISTORY`.
+///
+/// # Errors
+/// Returns an error if database operations fail.
+pub async fn backfill_history_for_video(
+    db: &sea_orm::DatabaseConnection,
+    video: &videos_entity::Model,
+) -> Result<()> {
+    let empty_diffs = find_empty_author_diffs(db, i64::from(video.id)).await?;
+
+    for diff_row in empty_diffs {
+        let Some(title) = &diff_row.title else {
+            continue;
+        };
+        if title.is_empty() {
+            continue;
+        }
+        if let Some(author) = find_historical_author(db, title).await? {
+            update_diff_author(db, diff_row.id, &author).await?;
+        }
+    }
+
+    videos_model::Model::update_status(db, video.id, STATUS_FETCHED_HISTORY)
+        .await
+        .map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
+
+    Ok(())
+}
+
+/// Fills empty `author` fields for `video` using Spotify search.
+/// Sets status to `STATUS_COMPLETED`.
+///
+/// # Errors
+/// Returns an error if database operations fail.
+pub async fn backfill_spotify_for_video(
+    db: &sea_orm::DatabaseConnection,
+    video: &videos_entity::Model,
+    spotify_client: &SpotifyClient,
+) -> Result<()> {
+    let empty_diffs = find_empty_author_diffs(db, i64::from(video.id)).await?;
+
+    for diff_row in empty_diffs {
+        let Some(title) = &diff_row.title else {
+            continue;
+        };
+        if title.is_empty() {
+            continue;
+        }
+
+        match spotify_client.search_artist(title).await {
+            Ok(Some(author)) => {
+                update_diff_author(db, diff_row.id, &author).await?;
+                update_diff_status(db, diff_row.id, STATUS_SPOTIFY_COMPLETED).await?;
+            }
+            Ok(None) => {
+                update_diff_status(db, diff_row.id, STATUS_SPOTIFY_FETCHED).await?;
+            }
+            Err(e) => {
+                tracing::warn!("Spotify search failed for '{}': {e}", title);
+            }
+        }
+    }
+
+    videos_model::Model::update_status(db, video.id, STATUS_COMPLETED)
+        .await
+        .map_err(|e| loco_rs::Error::Any(Box::new(e)))?;
+
+    Ok(())
 }
 
 /// Finds `song_diffs` with empty author linked to the video via `song_items.latest_diff_id`.


### PR DESCRIPTION
## 実装内容

###  Backend

`src/workers/song_items_creator.rs` (リファクタリング)
- 3つの per-video 処理関数を pub として切り出し：
  - process_song_items_for_video — コメント取得 → OpenAI 抽出 → song_items 作成
  - backfill_history_for_video — 履歴から著者補完
  - backfill_spotify_for_video — Spotify で著者補完
- SongItemsCreatorWorker のメソッドはこれらを呼ぶシンプルなループに変更（動作は変わらない）

`src/workers/setlist_fetch_worker.rs` (新規)
- Payload: { video_ids: Vec<i32>, force: bool }
- force=false: status < 20 の動画のみ処理（処理済みはスキップ）
- force=true: 既存 song_items/song_diffs を削除 → status をリセット → 再処理
- タイトルキーワードフィルターなし（管理者が明示指定した動画を処理）

`src/controllers/admin/videos.rs` (追加)
- POST /api/admin/videos/:id/fetch_setlist — 単一動画をキュー
- POST /api/admin/videos/bulk_fetch_setlist — 複数動画を一括キュー

###  Frontend

`useAdminVideos.ts` — `fetchSetlist()` / `bulkFetchSetlist()` を追加

`VideoList.tsx` — 以下を追加：
- チェックボックス列（全選択対応）
- ステータスバッジ（未処理 / 取得済 / セトリ作成済 / 完了 など）
- 未処理動画に「セトリ取得」、処理済みに「再取得」（force=true）ボタン
- 選択時に一括操作バーが出現（「セトリ取得」「強制再取得」）