### PR TITLE
hotfix: CIデプロイ時にNEXT_PUBLIC_API_BASE_URLを渡す

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -185,6 +185,8 @@ jobs:
       - name: Deploy to Cloudflare Workers
         run: pnpm cf:deploy
         env:
+          NEXT_PUBLIC_API_BASE_URL: https://vtuber-song-list-production.up.railway.app
+          NEXT_PUBLIC_APP_ENV: production
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 


### PR DESCRIPTION
## 概要
- mainマージ後、本番(https://vtuber-song.com)で `/api/*` が全て500エラーになる障害が発生
- 原因: `next.config.ts` の `/api/*` リライトは `NEXT_PUBLIC_API_BASE_URL` 未設定時 `http://localhost:5150` にフォールバックする設計だが、`ci.yaml` の `deploy` ジョブがビルド時にこの変数を渡していなかった。そのため本番Workerに到達不能な `localhost:5150` へのリライトが焼き込まれていた
- 応急対応として、正しいAPI URLを指定した手動 `pnpm cf:deploy` で本番は復旧済み。本PRは今後mainへマージするたびに同じ障害が再発しないようにする恒久対応

## 変更内容
- `ci.yaml` の `deploy` ジョブに `NEXT_PUBLIC_API_BASE_URL` (Railway上の本番バックエンドURL) と `NEXT_PUBLIC_APP_ENV=production` を追加

## Test plan
- [x] 手動デプロイで本番の `/api/channels` が200を返すことを確認済み
- [ ] 本PRマージ後、CI経由の自動デプロイでも `/api/channels` が200を返すことを確認

Refs #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)