### PR TITLE
fix: Cloudflare Web AnalyticsビーコンをCSPで許可

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -40,7 +40,7 @@ const nextConfig: NextConfig = {
             key: "Content-Security-Policy",
             value: [
               "default-src 'self'",
-              "script-src 'self' 'unsafe-inline'",
+              "script-src 'self' 'unsafe-inline' static.cloudflareinsights.com",
               "style-src 'self' 'unsafe-inline'",
               "img-src 'self' data: img.youtube.com yt3.googleusercontent.com yt3.ggpht.com",
               "font-src 'self'",

--- a/frontend/src/pages/_document.tsx
+++ b/frontend/src/pages/_document.tsx
@@ -7,6 +7,12 @@ export default function Document() {
       <body>
         <Main />
         <NextScript />
+        <script
+          async
+          type="module"
+          src="https://static.cloudflareinsights.com/beacon.min.js"
+          data-cf-beacon='{"token": "6c142f00d87c44598b3199b9c8eb949a"}'
+        />
       </body>
     </Html>
   );


### PR DESCRIPTION
## 概要
- 本番でCloudflare Web Analyticsのビーコン(`static.cloudflareinsights.com/beacon.min.js`)がCSPによりブロックされ、コンソールにエラーが出ていた
- Cloudflareダッシュボード側でWeb Analyticsを「自動挿入」から「JSスニペット手動インストール」に変更し、アプリ側で明示的に読み込む形にした

## 変更内容
- `frontend/src/pages/_document.tsx`: Cloudflareから発行されたビーコンスクリプトを`<body>`末尾に追加
- `frontend/next.config.ts`: CSPの`script-src`に`static.cloudflareinsights.com`を追加(`connect-src`はCloudflareプロキシ配下のためRUMデータが同一オリジンの`/cdn-cgi/rum`に送られる想定で変更不要)

## Test plan
- [x] `pnpm lint` / `pnpm tsc --noEmit` / `pnpm build` すべて成功
- [ ] マージ後、本番のブラウザコンソールでCSP違反エラーが消えていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)