### PR TITLE
fix: CloudflareのRUM送信先をCSPのconnect-srcで許可

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -44,7 +44,7 @@ const nextConfig: NextConfig = {
               "style-src 'self' 'unsafe-inline'",
               "img-src 'self' data: img.youtube.com yt3.googleusercontent.com yt3.ggpht.com",
               "font-src 'self'",
-              "connect-src 'self'",
+              "connect-src 'self' cloudflareinsights.com",
               "frame-ancestors 'none'",
             ].join("; "),
           },


### PR DESCRIPTION
## 概要
- #94でWeb Analyticsのビーコンスクリプト読み込み(`script-src`)は許可したが、データ送信先(`connect-src`)の見直しが漏れていた
- 手動インストールのWeb Analyticsビーコンは同一オリジンの`/cdn-cgi/rum`ではなく`https://cloudflareinsights.com/cdn-cgi/rum`へ直接送信するため、本番で以下のCSP違反が発生していた

```
Content-Security-Policy: ... connect-src ... "connect-src 'self'"
```

## 変更内容
- `frontend/next.config.ts`: CSPの`connect-src`に`cloudflareinsights.com`を追加

## Test plan
- [x] `pnpm lint` / `pnpm tsc --noEmit` 成功
- [ ] マージ後、本番のブラウザコンソールでCSP違反エラーが消えていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)